### PR TITLE
Add workaround for PHP Bug #76919

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/) 
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [1.3.0] - 2019-03-28
+### Added
+- Strip square brackets from server provided IPs, workaround for [PHP Bug #76919](https://bugs.php.net/bug.php?id=76919)
 
 ## [1.2.0] - 2019-01-13
 ### Added
@@ -77,6 +81,7 @@ First version
 [#13]: https://github.com/middlewares/client-ip/issues/13
 [#14]: https://github.com/middlewares/client-ip/issues/14
 
+[1.3.0]: https://github.com/middlewares/client-ip/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/middlewares/client-ip/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/middlewares/client-ip/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/middlewares/client-ip/compare/v1.0.1...v1.0.2

--- a/src/ClientIp.php
+++ b/src/ClientIp.php
@@ -189,9 +189,10 @@ class ClientIp implements MiddlewareInterface
     private function getLocalIp(ServerRequestInterface $request)
     {
         $server = $request->getServerParams();
+        $ip = trim($server['REMOTE_ADDR'] ?? '', '[]');
 
-        if (!empty($server['REMOTE_ADDR']) && self::isValid($server['REMOTE_ADDR'])) {
-            return $server['REMOTE_ADDR'];
+        if (self::isValid($ip)) {
+            return $ip;
         }
     }
 

--- a/tests/ClientIpTest.php
+++ b/tests/ClientIpTest.php
@@ -79,6 +79,21 @@ class ClientIpTest extends TestCase
         $this->assertEquals('123.123.123.123', (string) $response->getBody());
     }
 
+    public function testClientIpV6NotProxy()
+    {
+        $request = Factory::createServerRequest('GET', '/', ['REMOTE_ADDR' => '[::1]'])
+            ->withHeader('X-Forwarded', '2001:0db8:85a3:0000:0000:8a2e:0370:7334');
+
+        $response = Dispatcher::run([
+            new ClientIp(),
+            function ($request) {
+                echo $request->getAttribute('client-ip');
+            },
+        ], $request);
+
+        $this->assertEquals('::1', (string) $response->getBody());
+    }
+
     public function testCustomAttribute()
     {
         $request = Factory::createServerRequest('GET', '/', ['REMOTE_ADDR' => '123.123.123.123']);


### PR DESCRIPTION
Strip square brackets from server IPs to handle IPv6 with port.